### PR TITLE
Split command line arguments

### DIFF
--- a/boost-test.el
+++ b/boost-test.el
@@ -95,7 +95,7 @@
     (setq default-directory (file-name-directory test-prog))
 
     (message "starting test(s)...")
-    (let ((proc (start-process test-prog buf test-prog "--output_format=XML --log_level=all --repor_level=detailed")))
+    (let ((proc (start-process test-prog buf test-prog "--output_format=XML" "--log_level=all" "--report_level=detailed")))
       (let ((sentinel (lambda (process signal)
                         (unwind-protect
                             (with-current-buffer (process-buffer process)


### PR DESCRIPTION
Thanks for a very useful mode. When using this mode against Emacs 26 I started getting errors, as if the arguments were not reaching the boost test binary:

```
error in process sentinel: xml-parse-tag-1: XML: (Well-Formed) Couldn’t parse tag: 3;49m=<HRF|
error in process sentinel: XML: (Well-Formed) Couldn’t parse tag: 3;49m=<HRF|
```

I then tried splitting them out into a list and got the mode working again. Not sure if this is the best fix possible, but works for me with Emacs 26.1 :-)

Thanks again.